### PR TITLE
Upgrade to Traefik2.2

### DIFF
--- a/setup/crds/traefik-crds.yaml
+++ b/setup/crds/traefik-crds.yaml
@@ -16,21 +16,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: ingressroutetcps.traefik.containo.us
-
-spec:
-  group: traefik.containo.us
-  version: v1alpha1
-  names:
-    kind: IngressRouteTCP
-    plural: ingressroutetcps
-    singular: ingressroutetcp
-  scope: Namespaced
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: middlewares.traefik.containo.us
 
 spec:
@@ -46,7 +31,38 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: ingressroutetcps.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: IngressRouteTCP
+    plural: ingressroutetcps
+    singular: ingressroutetcp
+  scope: Namespaced
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressrouteudps.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: IngressRouteUDP
+    plural: ingressrouteudps
+    singular: ingressrouteudp
+  scope: Namespaced
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: tlsoptions.traefik.containo.us
+
 spec:
   group: traefik.containo.us
   version: v1alpha1
@@ -55,11 +71,28 @@ spec:
     plural: tlsoptions
     singular: tlsoption
   scope: Namespaced
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlsstores.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: TLSStore
+    plural: tlsstores
+    singular: tlsstore
+  scope: Namespaced
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: traefikservices.traefik.containo.us
+
 spec:
   group: traefik.containo.us
   version: v1alpha1

--- a/setup/templates/ingress/01-role.yml
+++ b/setup/templates/ingress/01-role.yml
@@ -32,38 +32,12 @@ rules:
       - traefik.containo.us
     resources:
       - middlewares
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - traefik.containo.us
-    resources:
       - ingressroutes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - traefik.containo.us
-    resources:
-      - ingressroutetcps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - traefik.containo.us
-    resources:
-      - tlsoptions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - traefik.containo.us
-    resources:
       - traefikservices
+      - ingressroutetcps
+      - ingressrouteudps
+      - tlsoptions
+      - tlsstores
     verbs:
       - get
       - list

--- a/setup/templates/ingress/02-service.yaml
+++ b/setup/templates/ingress/02-service.yaml
@@ -1,4 +1,4 @@
-# Servive for Ingress-Traefik
+# Service for Ingress-Traefik
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,6 +13,9 @@ spec:
       name: websecure
       port: 443
       targetPort: 443
+    - protocol: TCP
+      name: admin
+      port: 8080
   selector:
     app: traefik
   type: LoadBalancer

--- a/setup/templates/ingress/04-deployment.yml
+++ b/setup/templates/ingress/04-deployment.yml
@@ -22,13 +22,14 @@ spec:
            claimName: traefik-cert
       containers:
         - name: traefik
-          image: traefik:v2.1
+          image: traefik:v2.2
           imagePullPolicy: Always
           volumeMounts:
            - name: cert-vol
              mountPath: "/data"
           args:
             - --api.insecure
+            - --api.dashboard
             - --accesslog
             - --entrypoints.web.Address=:80
             - --entrypoints.websecure.Address=:443
@@ -44,3 +45,6 @@ spec:
               containerPort: 80
             - name: websecure
               containerPort: 443
+            - name: admin
+              containerPort: 8080
+

--- a/setup/templates/ingress/dashboard.yaml
+++ b/setup/templates/ingress/dashboard.yaml
@@ -1,0 +1,28 @@
+# enable the Traefik Dashboard
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: traefik-auth
+spec:
+  basicAuth:
+    secret: traefik-admin
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-dashboard
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+      kind: Rule
+      services:
+      - name: api@internal
+        kind: TraefikService
+      middlewares:
+        - name: traefik-auth
+  tls:
+    certResolver: default
+

--- a/setup/templates/ingress/users.yaml
+++ b/setup/templates/ingress/users.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: traefik-admin
+  namespace: default
+
+data:
+  users: |2
+    <fghfghjghjhgjkjhkhjkhjk> # create user&password with 'htpasswd -nb user password | openssl base64' 
+    # lool at https://docs.traefik.io/middlewares/basicauth/

--- a/setup/templates/ingress/users.yaml
+++ b/setup/templates/ingress/users.yaml
@@ -6,5 +6,5 @@ metadata:
 
 data:
   users: |2
-    <fghfghjghjhgjkjhkhjkhjk> # create user&password with 'htpasswd -nb user password | openssl base64' 
-    # lool at https://docs.traefik.io/middlewares/basicauth/
+    <your user and password hash base64 encoded> # create the string with 'htpasswd -nb user password | openssl base64' and paste it here 
+    # look at https://docs.traefik.io/middlewares/basicauth/


### PR DESCRIPTION
I´ve played around and set this to Traefik Version 2.2
A Traefik Dashbord ist also availible at `{name}.[domain}/dashboard/`
**trailing slash is mandatory**

Thank you for this exemple to learn K8s